### PR TITLE
Add support for MOVR and setup framework for multichain

### DIFF
--- a/coins/Addy.js
+++ b/coins/Addy.js
@@ -6,7 +6,7 @@ const Eth = require('./Eth')
 const ADDY_ETH_PAIR = '0xa5BF14BB945297447fE96f6cD1b31b40d31175CB'
 
 async function getPrice() {
-    const AddyWethPair = new ethers.Contract(ADDY_ETH_PAIR, PairABI, provider)
+    const AddyWethPair = new ethers.Contract(ADDY_ETH_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await AddyWethPair.getReserves()
     const EthPrice = await Eth.getPrice()
     return reserve0 / reserve1  * EthPrice

--- a/coins/Bone.js
+++ b/coins/Bone.js
@@ -8,14 +8,14 @@ const BONE_USDC_PAIR = '0x2cc05c660f35e8692ca99db95922cb744d44ef20'
 
 async function getPrice() {
     //usdc
-    const BoneUsdcPair = new ethers.Contract(BONE_USDC_PAIR, PairABI, provider)
+    const BoneUsdcPair = new ethers.Contract(BONE_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await BoneUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }
 
 
 async function subscribePair() {
-    const PupMaticPair = new ethers.Contract(BONE_USDC_PAIR, PairABI, provider)
+    const PupMaticPair = new ethers.Contract(BONE_USDC_PAIR, PairABI, provider.matic)
     PupMaticPair.on('Sync', async (reserve0, reserve1) => {
         const maticPrice = await Matic.getPrice()
         console.log('BONE: ' +  (reserve0 * 1e12) / reserve1)

--- a/coins/Bunny.js
+++ b/coins/Bunny.js
@@ -7,7 +7,7 @@ const Eth = require('./Eth')
 const BUNNY_WMATIC_PAIR = '0x62052b489cb5bc72a9dc8eeae4b24fd50639921a'
 async function getPrice() {
     // Bunny Bunny Pool (quickswap)
-    const MaticBunnyPair = new ethers.Contract(BUNNY_WMATIC_PAIR, PairABI, provider)
+    const MaticBunnyPair = new ethers.Contract(BUNNY_WMATIC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await MaticBunnyPair.getReserves()
     const priceInEth = reserve1 / reserve0
     const ethPrice = await Eth.getPrice()

--- a/coins/Dino.js
+++ b/coins/Dino.js
@@ -6,7 +6,7 @@ const PairABI = require('../abis/Pair.abi.json')
 const DOJO_USDC_PAIR = '0x3324af8417844e70b81555a6d1568d78f4d4bf1f'
 
 async function getPrice() {
-    const dinoUsdcPair = new ethers.Contract(DOJO_USDC_PAIR, PairABI, provider)
+    const dinoUsdcPair = new ethers.Contract(DOJO_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await dinoUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }

--- a/coins/Dojo.js
+++ b/coins/Dojo.js
@@ -6,7 +6,7 @@ const PairABI = require('../abis/Pair.abi.json')
 const DOJO_USDC_PAIR = '0xd30c6e1cfced1d3441f0e97945e2b914b3605fa6'
 
 async function getPrice() {
-    const dojoUsdcPair = new ethers.Contract(DOJO_USDC_PAIR, PairABI, provider)
+    const dojoUsdcPair = new ethers.Contract(DOJO_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await dojoUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }

--- a/coins/Dolph.js
+++ b/coins/Dolph.js
@@ -7,14 +7,14 @@ const DOLPH_USDC_PAIR = '0x7a9A82fbB67262064C442652099936815eD2f78C'
 
 async function getPrice() {
     //usdc
-    const DolphUsdcPair = new ethers.Contract(DOLPH_USDC_PAIR, PairABI, provider)
+    const DolphUsdcPair = new ethers.Contract(DOLPH_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await DolphUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }
 
 
 async function subscribePair() {
-    const PupMaticPair = new ethers.Contract(DOLPH_USDC_PAIR, PairABI, provider)
+    const PupMaticPair = new ethers.Contract(DOLPH_USDC_PAIR, PairABI, provider.matic)
     PupMaticPair.on('Sync', async (reserve0, reserve1) => {
         const maticPrice = await Matic.getPrice()
         console.log('DOLPH: ' +  (reserve0 * 1e12) / reserve1)

--- a/coins/Eth.js
+++ b/coins/Eth.js
@@ -6,7 +6,7 @@ const PairABI = require('../abis/Pair.abi.json')
 const WETH_USDC_PAIR = '0x853ee4b2a13f8a742d64c8f088be7ba2131f670d'
 
 async function getPrice() {
-    const WethUsdcPair = new ethers.Contract(WETH_USDC_PAIR, PairABI, provider)
+    const WethUsdcPair = new ethers.Contract(WETH_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await WethUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }

--- a/coins/Ice.js
+++ b/coins/Ice.js
@@ -6,7 +6,7 @@ const PairABI = require('../abis/Pair.abi.json')
 const ICE_USDC_PAIR = '0x34832D9AC4127a232C1919d840f7aaE0fcb7315B'
 
 async function getPrice() {
-    const iceUsdcPair = new ethers.Contract(ICE_USDC_PAIR, PairABI, provider)
+    const iceUsdcPair = new ethers.Contract(ICE_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await iceUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }

--- a/coins/Matic.js
+++ b/coins/Matic.js
@@ -6,7 +6,7 @@ const PairABI = require('../abis/Pair.abi.json')
 const MATIC_USDC_PAIR = '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827'
 
 async function getPrice() {
-    const maticUsdcPair = new ethers.Contract(MATIC_USDC_PAIR, PairABI, provider)
+    const maticUsdcPair = new ethers.Contract(MATIC_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await maticUsdcPair.getReserves()
     return (reserve1 * 1e12) / reserve0
 }

--- a/coins/Movr.js
+++ b/coins/Movr.js
@@ -1,0 +1,18 @@
+const provider = require('../provider')
+const { ethers } = require('ethers')
+const PairABI = require('../abis/Pair.abi.json')
+
+//solarbeam
+const MOVR_USDC = '0xe537f70a8b62204832B8Ba91940B77d3f79AEb81'
+
+async function getPrice() {
+    const UsdcPair = new ethers.Contract(MOVR_USDC, PairABI, provider.movr)
+    const [reserve0, reserve1] = await UsdcPair.getReserves()
+    return (reserve1 * 1e12) / reserve0
+}
+
+const Movr = {
+    getPrice,
+}
+
+module.exports = Movr

--- a/coins/PSpace.js
+++ b/coins/PSpace.js
@@ -7,7 +7,7 @@ const Eth = require('./Eth')
 const BUNNY_WETH_PAIR = '0x4e540fad17f1a51380Fa2BbA7185DBdF4f54A713'
 async function getPrice() {
     // Bunny Bunny Pool (quickswap)
-    const MaticBunnyPair = new ethers.Contract(BUNNY_WETH_PAIR, PairABI, provider)
+    const MaticBunnyPair = new ethers.Contract(BUNNY_WETH_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await MaticBunnyPair.getReserves()
     const priceInEth = reserve0 / reserve1
     const ethPrice = await Eth.getPrice()

--- a/coins/Pup.js
+++ b/coins/Pup.js
@@ -8,21 +8,21 @@ const PUP_USDC_PAIR = '0x767f8BD67a5f133BdDF3b285c5E2FD3D157A2cdC'
 const PUP_MATIC_PAIR = '0xBC68d2A5920c4ffaEa20E2BE48a0E09055481976'
 async function getPrice() {
     //usdc
-    const PupUsdcPair = new ethers.Contract(PUP_USDC_PAIR, PairABI, provider)
+    const PupUsdcPair = new ethers.Contract(PUP_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await PupUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }
 
 async function getPrice2() {
     //matic
-    const PupMaticPair = new ethers.Contract(PUP_MATIC_PAIR, PairABI, provider)
+    const PupMaticPair = new ethers.Contract(PUP_MATIC_PAIR, PairABI, provider.matic)
     const maticPrice = await Matic.getPrice()
     const [reserve0, reserve1] = await PupMaticPair.getReserves()
     return (reserve0 / reserve1) * maticPrice
 }
 
 async function subscribePair() {
-    const PupMaticPair = new ethers.Contract(PUP_MATIC_PAIR, PairABI, provider)
+    const PupMaticPair = new ethers.Contract(PUP_MATIC_PAIR, PairABI, provider.matic)
     PupMaticPair.on('Sync', async (reserve0, reserve1) => {
         const maticPrice = await Matic.getPrice()
         console.log('Pup: ' + (reserve0 / reserve1) * maticPrice)

--- a/coins/Pwing.js
+++ b/coins/Pwing.js
@@ -6,7 +6,7 @@ const PairABI = require('../abis/Pair.abi.json')
 const PWING_USDC = '0xaf623E96d38191038C48990Df298e07Fb77b56c3'
 
 async function getPrice() {
-    const pwingUsdcPair = new ethers.Contract(PWING_USDC, PairABI, provider)
+    const pwingUsdcPair = new ethers.Contract(PWING_USDC, PairABI, provider.matic)
     const [reserve0, reserve1] = await pwingUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }

--- a/coins/Qi.js
+++ b/coins/Qi.js
@@ -7,7 +7,7 @@ const Matic = require('./Matic')
 const MATIC_QI_PAIR = '0x9a8b2601760814019b7e6ee0052e25f1c623d1e6'
 async function getPrice() {
     // Qi Matic Pool (quickswap)
-    const QiMaticPair = new ethers.Contract(MATIC_QI_PAIR, PairABI, provider)
+    const QiMaticPair = new ethers.Contract(MATIC_QI_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await QiMaticPair.getReserves()
     const priceInMatic = reserve0 / reserve1
     const maticPrice = await Matic.getPrice()

--- a/coins/Raider.js
+++ b/coins/Raider.js
@@ -7,7 +7,7 @@ const Matic = require('./Matic')
 const RAIDER_MATIC_PAIR = '0x2E7d6490526C7d7e2FDEa5c6Ec4b0d1b9F8b25B7'
 
 async function getPrice() {
-    const raiderMaticPair = new ethers.Contract(RAIDER_MATIC_PAIR, PairABI, provider)
+    const raiderMaticPair = new ethers.Contract(RAIDER_MATIC_PAIR, PairABI, provider.matic)
     const maticPrice = await Matic.getPrice()
     const [reserve0, reserve1] = await raiderMaticPair.getReserves()
     return (reserve0 * maticPrice) / reserve1
@@ -15,7 +15,7 @@ async function getPrice() {
 
 
 async function subscribePair() {
-   const RaiderMaticPair = new ethers.Contract(RAIDER_MATIC_PAIR, PairABI, provider)
+   const RaiderMaticPair = new ethers.Contract(RAIDER_MATIC_PAIR, PairABI, provider.matic)
    RaiderMaticPair.on('Sync', async (reserve0, reserve1) => {
     const maticPrice = await Matic.getPrice()
     const raiderPrice = (reserve0 * maticPrice) / reserve1

--- a/coins/Titan.js
+++ b/coins/Titan.js
@@ -7,14 +7,14 @@ const TITAN_USDC_PAIR = '0x8af511761c74af631258d8ee6096679ff4838cde'
 
 async function getPrice() {
     //usdc
-    const TitanUsdcPair = new ethers.Contract(TITAN_USDC_PAIR, PairABI, provider)
+    const TitanUsdcPair = new ethers.Contract(TITAN_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await TitanUsdcPair.getReserves()
     return ((reserve0 * 1e12) / reserve1)
 }
 
 async function subscribePair() {
     const titanBalance = 77905660.795959579203091711
-    const PupMaticPair = new ethers.Contract(TITAN_USDC_PAIR, PairABI, provider)
+    const PupMaticPair = new ethers.Contract(TITAN_USDC_PAIR, PairABI, provider.matic)
     PupMaticPair.on('Sync', async (reserve0, reserve1) => {
         console.log('TITAN: ' + ((reserve0 * 1e12) / reserve1) * titanBalance)
     })

--- a/coins/WexPoly.js
+++ b/coins/WexPoly.js
@@ -6,7 +6,7 @@ const PairABI = require('../abis/Pair.abi.json')
 const WEX_USDC_PAIR = '0x5DE6a3CcA10d3F788EEdbD4923e31D4658bf6f9a'
 
 async function getPrice() {
-    const WexUsdcPair = new ethers.Contract(WEX_USDC_PAIR, PairABI, provider)
+    const WexUsdcPair = new ethers.Contract(WEX_USDC_PAIR, PairABI, provider.matic)
     const [reserve0, reserve1] = await WexUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }

--- a/coins/index.js
+++ b/coins/index.js
@@ -13,6 +13,7 @@ const Pwing = require('./Pwing')
 const Dolph = require('./Dolph')
 const Dino = require('./Dino')
 const Raider = require('./Raider')
+const Movr = require('./Movr')
 
 
 //exported coins are automatically fetched by the worker each 30s.

--- a/commands/movr.js
+++ b/commands/movr.js
@@ -1,0 +1,20 @@
+const { getPrice } = require('../coins/Movr')
+const { MessageEmbed } = require('discord.js')
+
+module.exports = async message => {
+    const price = await getPrice()
+    message.reply({
+        embed: {
+            title: 'MOVR',
+            thumbnail: {
+                url: 'https://pbs.twimg.com/profile_images/1402056766880464900/HNcouH0x_400x400.jpg'
+            },
+            fields: [
+                {
+                    name: 'Price',
+                    value: `**$${price}**`,
+                },
+            ],
+        },
+    })
+}

--- a/common/discordClient.js
+++ b/common/discordClient.js
@@ -25,6 +25,7 @@ const commands = {
     info: require('../commands/info'),
     gecko: require('../commands/gecko'),
     raider: require('../commands/raider'),
+    movr: require('../commands/movr'),
 }
 
 const client = new Discord.Client()

--- a/config/index.js
+++ b/config/index.js
@@ -13,7 +13,8 @@ const supportedCoins = [
     "DOLPH",
     "ICE",
     "DINO",
-    "RAIDER"
+    "RAIDER",
+    "MOVR"
 ]
 
 const addresses = {

--- a/provider/index.js
+++ b/provider/index.js
@@ -1,4 +1,6 @@
 const { ethers } = require('ethers')
-const provider = new ethers.providers.JsonRpcProvider(process.env.INFURA_RPC)
+const matic = new ethers.providers.JsonRpcProvider(process.env.MATIC_RPC)
 
-module.exports = provider
+module.exports = {
+    matic,
+}

--- a/provider/index.js
+++ b/provider/index.js
@@ -1,6 +1,8 @@
 const { ethers } = require('ethers')
 const matic = new ethers.providers.JsonRpcProvider(process.env.MATIC_RPC)
+const movr = new ethers.providers.JsonRpcProvider(process.env.MOVR_RPC)
 
 module.exports = {
     matic,
+    movr,
 }


### PR DESCRIPTION
1. Expand chain provider setup to support multiple chains

This replaces the provider export with an object so instead of using 
`ethers.Contract(PAIR_CONTRACT, PairABI, provider)`

we now use 

`ethers.Contract(PAIR_CONTRACT, PairABI, provider.matic)`

or 

`ethers.Contract(PAIR_CONTRACT, PairABI, provider.movr)`

This can be expanded by adding new entries in the provider object defined in `provider/index.js`

2. Renames environment variable INFURA_RPC as MATIC_RPC and adds new MOVR_RPC variable for movr provider

3. Adds MOVR coin price based on solarbeam.io WMOVR liquidity pool