### PR TITLE
Fix FTM price check

### DIFF
--- a/coins/Ftm.js
+++ b/coins/Ftm.js
@@ -7,7 +7,7 @@ const FTM_USDC_LP = `0x2b4C76d0dc16BE1C31D4C1DC53bF9B45987Fc75c`
 
 async function getPrice() {
     const FtmUsdcPair = new ethers.Contract(FTM_USDC_LP, PairABI, provider.ftm)
-    [reserve0, reserve1] = await FtmUsdcPair.getReserves()
+    const [reserve0, reserve1] = await FtmUsdcPair.getReserves()
     return (reserve0 * 1e12) / reserve1
 }
 


### PR DESCRIPTION
Adds missing `const` scope to reserves output of `FtmUsdcPair.getReserves()` in `coins/Ftm.js`

`!FTM` command should work now

![image](https://user-images.githubusercontent.com/32209658/136843974-e7ad63d7-18ea-4a46-b57f-339463157e77.png)
